### PR TITLE
Better paddings for the old feed

### DIFF
--- a/old-feed.user.js
+++ b/old-feed.user.js
@@ -74,7 +74,14 @@
             followingFeedWrapper.querySelector(".ajax-pagination-btn").addEventListener("click", () => {
                 userHasLoadedMore = true;
             });
-            localStorage.setItem("dashboardCache", html);
+            // Apply pretty paddings for feeds.
+            followingFeedWrapper.querySelectorAll(".body > .Details > .py-4, .body > .py-4").forEach((e) => {
+                e.classList.remove("py-4");
+                e.classList.add("py-3");
+            });
+            followingFeedWrapper.querySelector(".body > .Details > div").style.setProperty('padding-top', 'var(--base-size-4, 4px)', 'important');
+            // Saving the edited content for the cache.
+            localStorage.setItem("dashboardCache", followingFeedWrapper.innerHTML);
         });
     }
 })();


### PR DESCRIPTION
The PR also saves the `innerHTML` of the feed container into caches to make sure it exactly matches the last content.

| Before | After |
|:------:|:------:|
| ![image](https://github.com/Gerrit0/old-github-feed/assets/15884415/b5be4a69-592a-4377-84b6-1722326c6090) | ![image](https://github.com/Gerrit0/old-github-feed/assets/15884415/b868aefe-cb90-4e7c-a9b2-e549e9ed9e35) |